### PR TITLE
CNC-4028 Move salesforce api version sub from webapp to api-rest

### DIFF
--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -32,7 +32,7 @@ module Salesforceapi
         @refresh_token = refresh_token
         @client_id = client_id
         @client_secret = client_secret
-        @api_version = "54.0"
+        @api_version = "21.0"
         # @api_version = "21.0"
         # @metadata_uri = metadata_uri.gsub("{version}", @api_version)
         @metadata_uri = metadata_uri.gsub("{version}", @api_version)

--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -32,7 +32,7 @@ module Salesforceapi
         @refresh_token = refresh_token
         @client_id = client_id
         @client_secret = client_secret
-        @api_version = "57.0"
+        @api_version = "54.0"
         # @api_version = "21.0"
         # @metadata_uri = metadata_uri.gsub("{version}", @api_version)
         @metadata_uri = metadata_uri.gsub("{version}", @api_version)

--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -32,9 +32,7 @@ module Salesforceapi
         @refresh_token = refresh_token
         @client_id = client_id
         @client_secret = client_secret
-        @api_version = "21.0"
-        # @api_version = "21.0"
-        # @metadata_uri = metadata_uri.gsub("{version}", @api_version)
+        @api_version = "57.0"
         @metadata_uri = metadata_uri.gsub("{version}", @api_version)
         @ssl_port = 443  # TODO, right SF use port 443 for all HTTPS traffic.
 
@@ -43,7 +41,7 @@ module Salesforceapi
 
       def create(object, attributes)
         config_authorization!
-        path = "/services/data/#{@api_version}/sobjects/#{object}/"
+        path = "/services/data/v#{@api_version}/sobjects/#{object}/"
         target = @instance_uri + path
 
         self.class.base_uri @instance_uri
@@ -62,7 +60,7 @@ module Salesforceapi
       end
 
       def describe(object)
-        path = "/services/data/#{@api_version}/sobjects/#{object}/describe"
+        path = "/services/data/v#{@api_version}/sobjects/#{object}/describe"
         config_authorization!
         target = @instance_uri + path
 
@@ -78,7 +76,7 @@ module Salesforceapi
       end
 
       def resources
-        path = "/services/data/#{@api_version}"
+        path = "/services/data/v#{@api_version}"
         config_authorization!
         target = @instance_uri + path
 
@@ -117,7 +115,6 @@ module Salesforceapi
 
 
       def add_custom_field(attributes)
-        binding.pry
         config_authorization!
         auth_header = {
           "Authorization" => "OAuth " + @access_token,

--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -31,8 +31,8 @@ module Salesforceapi
         @refresh_token = refresh_token
         @client_id = client_id
         @client_secret = client_secret
-        @metadata_uri = metadata_uri
         @api_version = "v54.0"
+        @metadata_uri = metadata_uri.gsub("{version}", @api_version)
         @ssl_port = 443  # TODO, right SF use port 443 for all HTTPS traffic.
 
       end

--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -28,7 +28,6 @@ module Salesforceapi
       end
 
       def initialize(refresh_token, metadata_uri, client_id, client_secret)
-        binding.pry
         @refresh_token = refresh_token
         @client_id = client_id
         @client_secret = client_secret

--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -28,10 +28,13 @@ module Salesforceapi
       end
 
       def initialize(refresh_token, metadata_uri, client_id, client_secret)
+        binding.pry
         @refresh_token = refresh_token
         @client_id = client_id
         @client_secret = client_secret
-        @api_version = "v57.0"
+        @api_version = "57.0"
+        # @api_version = "21.0"
+        # @metadata_uri = metadata_uri.gsub("{version}", @api_version)
         @metadata_uri = metadata_uri.gsub("{version}", @api_version)
         @ssl_port = 443  # TODO, right SF use port 443 for all HTTPS traffic.
 
@@ -114,6 +117,7 @@ module Salesforceapi
 
 
       def add_custom_field(attributes)
+        binding.pry
         config_authorization!
         auth_header = {
           "Authorization" => "OAuth " + @access_token,

--- a/lib/salesforceapi-rest.rb
+++ b/lib/salesforceapi-rest.rb
@@ -31,7 +31,7 @@ module Salesforceapi
         @refresh_token = refresh_token
         @client_id = client_id
         @client_secret = client_secret
-        @api_version = "v54.0"
+        @api_version = "v57.0"
         @metadata_uri = metadata_uri.gsub("{version}", @api_version)
         @ssl_port = 443  # TODO, right SF use port 443 for all HTTPS traffic.
 

--- a/lib/salesforceapi-rest/version.rb
+++ b/lib/salesforceapi-rest/version.rb
@@ -1,5 +1,5 @@
 module Salesforceapi
   module Rest
-    VERSION = "0.0.5"
+    VERSION = "0.0.6"
   end
 end


### PR DESCRIPTION
Issue: [CNC-4028](https://unbounce.atlassian.net/browse/CNC-4028)

Updating the salesforce API version used in `salesforcerest-api` and consolidating API versions by removing version specification within `lp-webapp`.

Previously methods within salesforcerest-API used different API versions:
`create` -> v54.0
`describe` -> v54.0
`resources` -> v54.0
`add_custom_field` -> v21.0, as supplied from webapp in initialization argument

This PR removes the API specification from webapp, and makes all methods above use the same API version.

[CNC-4028]: https://unbounce.atlassian.net/browse/CNC-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ