### PR TITLE
Add dependabot-agent workflow

### DIFF
--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -1,0 +1,21 @@
+name: Dependabot Agent
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  checks: read
+
+jobs:
+  dependabot:
+    if: |
+      github.actor == 'dependabot[bot]' &&
+      startsWith(github.event.pull_request.head.ref, 'dependabot/')
+    uses: unbounce/agentic-tools/.github/workflows/dependabot-agent.yml@v1
+    with:
+      slack_channel: ''
+    secrets: inherit


### PR DESCRIPTION
Adds the Dependabot Agent GitHub Actions workflow: auto-merges green patch/minor Dependabot PRs, escalates majors, and posts a Claude diagnosis on red CI. Slack notifications are disabled by default — set the `slack_channel` input to your team's channel to enable them.